### PR TITLE
PRMDR-442 enable intelligent tiering

### DIFF
--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -60,6 +60,35 @@ module "ndr-lloyd-george-store" {
   ]
 }
 
+# S3 Intelligent-Tiering
+resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bucket" {
+  bucket = module.ndr-lloyd-george-store.bucket_id
+  name   = "LgTieringEntireBucket"
+
+  tiering {
+    access_tier = "DEEP_ARCHIVE_ACCESS"
+    days        = 90
+  }
+  tiering {
+    access_tier = "ARCHIVE_ACCESS"
+    days        = 60
+  }
+}
+
+resource "aws_s3_bucket_intelligent_tiering_configuration" "doc-store-tiering-entire-bucket" {
+  bucket = module.ndr-document-store.bucket_id
+  name   = "DocStoreTieringEntireBucket"
+
+  tiering {
+    access_tier = "DEEP_ARCHIVE_ACCESS"
+    days        = 90
+  }
+  tiering {
+    access_tier = "ARCHIVE_ACCESS"
+    days        = 60
+  }
+}
+
 # Lifecycle Rules
 resource "aws_s3_bucket_lifecycle_configuration" "lg-lifecycle-rules" {
   bucket = module.ndr-lloyd-george-store.bucket_id

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -67,7 +67,7 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bu
 
   tiering {
     access_tier = "DEEP_ARCHIVE_ACCESS"
-    days        = 120
+    days        = 180
   }
   tiering {
     access_tier = "ARCHIVE_ACCESS"
@@ -81,7 +81,7 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "doc-store-tiering-en
 
   tiering {
     access_tier = "DEEP_ARCHIVE_ACCESS"
-    days        = 120
+    days        = 180
   }
   tiering {
     access_tier = "ARCHIVE_ACCESS"

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -64,6 +64,7 @@ module "ndr-lloyd-george-store" {
 resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bucket" {
   bucket = module.ndr-lloyd-george-store.bucket_id
   name   = "LgTieringEntireBucket"
+  count = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
 
   tiering {
     access_tier = "DEEP_ARCHIVE_ACCESS"
@@ -78,6 +79,7 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bu
 resource "aws_s3_bucket_intelligent_tiering_configuration" "doc-store-tiering-entire-bucket" {
   bucket = module.ndr-document-store.bucket_id
   name   = "DocStoreTieringEntireBucket"
+  count = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
 
   tiering {
     access_tier = "DEEP_ARCHIVE_ACCESS"

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -67,11 +67,11 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bu
 
   tiering {
     access_tier = "DEEP_ARCHIVE_ACCESS"
-    days        = 90
+    days        = 120
   }
   tiering {
     access_tier = "ARCHIVE_ACCESS"
-    days        = 60
+    days        = 90
   }
 }
 

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -64,7 +64,7 @@ module "ndr-lloyd-george-store" {
 resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bucket" {
   bucket = module.ndr-lloyd-george-store.bucket_id
   name   = "LgTieringEntireBucket"
-  count = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
+  count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
 
   tiering {
     access_tier = "DEEP_ARCHIVE_ACCESS"
@@ -79,7 +79,7 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bu
 resource "aws_s3_bucket_intelligent_tiering_configuration" "doc-store-tiering-entire-bucket" {
   bucket = module.ndr-document-store.bucket_id
   name   = "DocStoreTieringEntireBucket"
-  count = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
+  count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
 
   tiering {
     access_tier = "DEEP_ARCHIVE_ACCESS"

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -65,30 +65,12 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bu
   bucket = module.ndr-lloyd-george-store.bucket_id
   name   = "LgTieringEntireBucket"
   count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
-
-  tiering {
-    access_tier = "DEEP_ARCHIVE_ACCESS"
-    days        = 180
-  }
-  tiering {
-    access_tier = "ARCHIVE_ACCESS"
-    days        = 90
-  }
 }
 
 resource "aws_s3_bucket_intelligent_tiering_configuration" "doc-store-tiering-entire-bucket" {
   bucket = module.ndr-document-store.bucket_id
   name   = "DocStoreTieringEntireBucket"
   count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
-
-  tiering {
-    access_tier = "DEEP_ARCHIVE_ACCESS"
-    days        = 180
-  }
-  tiering {
-    access_tier = "ARCHIVE_ACCESS"
-    days        = 90
-  }
 }
 
 # Lifecycle Rules

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -111,6 +111,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "lg-lifecycle-rules" {
   rule {
     id     = "default-to-intelligent-tiering"
     status = "Enabled"
+    transition {
+      storage_class = "INTELLIGENT_TIERING"
+    }
   }
 }
 
@@ -149,6 +152,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "doc-store-lifecycle-rules" {
   rule {
     id     = "default-to-intelligent-tiering"
     status = "Enabled"
+    transition {
+      storage_class = "INTELLIGENT_TIERING"
+    }
   }
 }
 

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -109,7 +109,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "lg-lifecycle-rules" {
     }
   }
   rule {
-    count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
     id     = "default-to-intelligent-tiering"
     status = "Enabled"
   }
@@ -148,7 +147,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "doc-store-lifecycle-rules" {
     }
   }
   rule {
-    #    count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
     id     = "default-to-intelligent-tiering"
     status = "Enabled"
   }

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -60,19 +60,6 @@ module "ndr-lloyd-george-store" {
   ]
 }
 
-# S3 Intelligent-Tiering
-resource "aws_s3_bucket_intelligent_tiering_configuration" "lg-tiering-entire-bucket" {
-  bucket = module.ndr-lloyd-george-store.bucket_id
-  name   = "LgTieringEntireBucket"
-  count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
-}
-
-resource "aws_s3_bucket_intelligent_tiering_configuration" "doc-store-tiering-entire-bucket" {
-  bucket = module.ndr-document-store.bucket_id
-  name   = "DocStoreTieringEntireBucket"
-  count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
-}
-
 # Lifecycle Rules
 resource "aws_s3_bucket_lifecycle_configuration" "lg-lifecycle-rules" {
   bucket = module.ndr-lloyd-george-store.bucket_id
@@ -121,6 +108,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "lg-lifecycle-rules" {
       }
     }
   }
+  rule {
+    count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
+    id     = "default-to-intelligent-tiering"
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "doc-store-lifecycle-rules" {
@@ -154,6 +146,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "doc-store-lifecycle-rules" {
         value = "true"
       }
     }
+  }
+  rule {
+    #    count  = contains(["ndra", "ndrb", "ndrc", "ndrd"], terraform.workspace) ? 0 : 1
+    id     = "default-to-intelligent-tiering"
+    status = "Enabled"
   }
 }
 

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -81,11 +81,11 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "doc-store-tiering-en
 
   tiering {
     access_tier = "DEEP_ARCHIVE_ACCESS"
-    days        = 90
+    days        = 120
   }
   tiering {
     access_tier = "ARCHIVE_ACCESS"
-    days        = 60
+    days        = 90
   }
 }
 

--- a/infrastructure/modules/s3/iam.tf
+++ b/infrastructure/modules/s3/iam.tf
@@ -28,7 +28,6 @@ resource "aws_iam_policy" "s3_document_data_policy" {
           "s3:GetObjectTagging",
           "s3:PutObjectTagging",
           "s3:GetObjectVersion",
-          "s3:PutIntelligentTieringConfiguration"
         ],
         "Resource" : ["${aws_s3_bucket.bucket.arn}/*", "${aws_s3_bucket.bucket.arn}/*"]
       }

--- a/infrastructure/modules/s3/iam.tf
+++ b/infrastructure/modules/s3/iam.tf
@@ -27,7 +27,8 @@ resource "aws_iam_policy" "s3_document_data_policy" {
           "s3:GetObjectVersionAcl",
           "s3:GetObjectTagging",
           "s3:PutObjectTagging",
-          "s3:GetObjectVersion"
+          "s3:GetObjectVersion",
+          "s3:PutIntelligentTieringConfiguration"
         ],
         "Resource" : ["${aws_s3_bucket.bucket.arn}/*", "${aws_s3_bucket.bucket.arn}/*"]
       }


### PR DESCRIPTION
New rule can be seen on AWS for ndrc LG and docstore buckets, under Lifecycle configuration