### PR TITLE
PRMDR-456: drop invalid header fields

### DIFF
--- a/infrastructure/modules/ecs/lb.tf
+++ b/infrastructure/modules/ecs/lb.tf
@@ -5,6 +5,7 @@ resource "aws_lb" "ecs_lb" {
   security_groups    = [aws_security_group.ndr_ecs_sg.id]
   subnets            = [for subnet in var.public_subnets : subnet]
   enable_deletion_protection = true
+  drop_invalid_header_fields = true
 
   tags = {
     Name        = "${terraform.workspace}-lb-${var.ecs_cluster_name}"


### PR DESCRIPTION
This will cause the load balancer to only include header fields we require, reducing our cybersecurity surface area for vulnerabilities