### PR TITLE
[PRMDR-527] amend lambda name

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -8,7 +8,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.16.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.1 |
 
 ## Modules
 

--- a/infrastructure/lambda-login-redirect.tf
+++ b/infrastructure/lambda-login-redirect.tf
@@ -42,7 +42,7 @@ module "login_redirect_alarm" {
   source               = "./modules/lambda_alarms"
   lambda_function_name = module.login_redirect_lambda.function_name
   lambda_timeout       = module.login_redirect_lambda.timeout
-  lambda_name          = "authoriser_handler"
+  lambda_name          = "login_redirect_handler"
   namespace            = "AWS/Lambda"
   alarm_actions        = [module.login_redirect-alarm_topic.arn]
   ok_actions           = [module.login_redirect-alarm_topic.arn]


### PR DESCRIPTION
this alarm had the wrong lambda name - amended and alarms now showing on ndrb