### PR TITLE
[PRMDR-540]

### DIFF
--- a/infrastructure/queues.tf
+++ b/infrastructure/queues.tf
@@ -24,7 +24,7 @@ module "sqs-lg-bulk-upload-metadata-queue" {
   max_visibility       = 1020
   enable_fifo          = true
   enable_deduplication = true
-  delay = 60
+  delay                = 60
 }
 
 module "sqs-lg-bulk-upload-invalid-queue" {

--- a/infrastructure/queues.tf
+++ b/infrastructure/queues.tf
@@ -24,6 +24,7 @@ module "sqs-lg-bulk-upload-metadata-queue" {
   max_visibility       = 1020
   enable_fifo          = true
   enable_deduplication = true
+  delay = 60
 }
 
 module "sqs-lg-bulk-upload-invalid-queue" {


### PR DESCRIPTION
Adding a minute delay to the sqs bulk upload metadata queue to allow time for Virus Scanner to trigger in the event a file has not yet been scanned