### PR TITLE
PRMP-1280 Lambda default memory | 128 -> 512

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,49 +2,56 @@
 
 ## Prerequisites
 
-Ensure the following Prereqs are installed
+Ensure the following Prereqs are installed:
 
-### [Terraform Docs](https://terraform-docs.io/) - for formatting Terraform documentation
+1. [Terraform Docs](https://terraform-docs.io/) - For formatting Terraform documentation:
 
-#### If using Windows
-```bash
-chocolatey install terraform-docs
-```
+    If using Windows:
 
-#### If using Mac:
-```bash
-brew install terraform-docs
-```
-   
-##### If using Linux/WSL
-- Install precompiled binary: - (this documentation assumes latest version is `v0.19.0`) - latest binary can be found here https://github.com/terraform-docs/terraform-docs/releases
     ```bash
-    curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.19.0/terraform-docs-v0.19.0-$(uname)-amd64.tar.gz
-    tar -xzf terraform-docs.tar.gz
-    chmod +x terraform-docs
+    chocolatey install terraform-docs
     ```
 
-- Add to your $PATH (replace `YOURUSERNAME` with your linux username):
+    If using Mac:
+
     ```bash
-    mv terraform-docs /home/YOURUSERNAME/.local/bin/terraform-docs
-    ```
-  
-- Verify this has worked with:
-    ```bash
-    whereis terraform-docs
-    ```
-  
-- Make sure that the line endings on the `create-terraform-docs.sh` script are in UNIX format by running:
-    ```bash
-    cd scripts
-    dos2unix create-terraform-docs.sh
+    brew install terraform-docs
     ```
 
+    If using Linux/WSL:
 
-### [findutils](https://www.gnu.org/software/findutils/) - Needed for scripts running on MacOSX
-```bash
-brew install findutils
-```
+    - Install precompiled binary: - (this documentation assumes latest version is `v0.19.0`) - latest binary can be found here <https://github.com/terraform-docs/terraform-docs/releases>
+
+        ```bash
+        curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.19.0/terraform-docs-v0.19.0-$(uname)-amd64.tar.gz
+        tar -xzf terraform-docs.tar.gz
+        chmod +x terraform-docs
+        ```
+
+    - Add to your $PATH (replace `YOURUSERNAME` with your linux username):
+
+        ```bash
+        mv terraform-docs /home/YOURUSERNAME/.local/bin/terraform-docs
+        ```
+
+    - Verify this has worked with:
+
+        ```bash
+        whereis terraform-docs
+        ```
+
+    - Make sure that the line endings on the `create-terraform-docs.sh` script are in UNIX format by running:
+
+        ```bash
+        cd scripts
+        dos2unix create-terraform-docs.sh
+        ```
+
+2. [findutils](https://www.gnu.org/software/findutils/) - *If running on MacOSX*
+
+    ```bash
+    brew install findutils
+    ```
 
 ## Repository best practices
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,49 @@
 
 ## Prerequisites
 
-Ensure the following Prereqs are installed first (can use brew on Mac/Linux or Chocolatey on Windows)
+Ensure the following Prereqs are installed
 
-- [Terraform Docs](https://terraform-docs.io/) - for formatting Terraform documentation
+### [Terraform Docs](https://terraform-docs.io/) - for formatting Terraform documentation
 
+#### If using Windows
+```bash
+chocolatey install terraform-docs
+```
+
+#### If using Mac:
+```bash
+brew install terraform-docs
+```
+   
+##### If using Linux/WSL
+- Install precompiled binary: - (this documentation assumes latest version is `v0.19.0`) - latest binary can be found here https://github.com/terraform-docs/terraform-docs/releases
     ```bash
-    brew install terraform-docs
+    curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.19.0/terraform-docs-v0.19.0-$(uname)-amd64.tar.gz
+    tar -xzf terraform-docs.tar.gz
+    chmod +x terraform-docs
     ```
 
-- [findutils](https://www.gnu.org/software/findutils/) - Needed for scripts running on MacOSX
-
+- Add to your $PATH (replace `YOURUSERNAME` with your linux username):
     ```bash
-    brew install findutils
+    mv terraform-docs /home/YOURUSERNAME/.local/bin/terraform-docs
     ```
+  
+- Verify this has worked with:
+    ```bash
+    whereis terraform-docs
+    ```
+  
+- Make sure that the line endings on the `create-terraform-docs.sh` script are in UNIX format by running:
+    ```bash
+    cd scripts
+    dos2unix create-terraform-docs.sh
+    ```
+
+
+### [findutils](https://www.gnu.org/software/findutils/) - Needed for scripts running on MacOSX
+```bash
+brew install findutils
+```
 
 ## Repository best practices
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -8,7 +8,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.73.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 

--- a/infrastructure/lambda-authoriser.tf
+++ b/infrastructure/lambda-authoriser.tf
@@ -22,7 +22,6 @@ module "authoriser-lambda" {
   http_methods                  = ["GET"]
   is_gateway_integration_needed = false
   is_invoked_from_gateway       = true
-  memory_size                   = 256
 
   depends_on = [
     aws_iam_policy.ssm_policy_authoriser,

--- a/infrastructure/lambda-bulk-upload-metadata.tf
+++ b/infrastructure/lambda-bulk-upload-metadata.tf
@@ -24,7 +24,6 @@ module "bulk-upload-metadata-lambda" {
   }
   is_gateway_integration_needed = false
   is_invoked_from_gateway       = false
-  memory_size                   = 512
 
   depends_on = [
     module.ndr-bulk-staging-store,

--- a/infrastructure/lambda-bulk-upload-report.tf
+++ b/infrastructure/lambda-bulk-upload-report.tf
@@ -23,7 +23,6 @@ module "bulk-upload-report-lambda" {
   }
   is_gateway_integration_needed = false
   is_invoked_from_gateway       = false
-  memory_size                   = 512
   lambda_timeout                = 45
 
   depends_on = [

--- a/infrastructure/lambda-bulk-upload.tf
+++ b/infrastructure/lambda-bulk-upload.tf
@@ -33,7 +33,6 @@ module "bulk-upload-lambda" {
 
   is_gateway_integration_needed  = false
   is_invoked_from_gateway        = false
-  memory_size                    = 512
   lambda_timeout                 = 900
   reserved_concurrent_executions = local.bulk_upload_lambda_concurrent_limit
 

--- a/infrastructure/lambda-create-doc-ref.tf
+++ b/infrastructure/lambda-create-doc-ref.tf
@@ -81,7 +81,6 @@ module "create-doc-ref-lambda" {
   rest_api_id       = aws_api_gateway_rest_api.ndr_doc_store_api.id
   resource_id       = module.create-doc-ref-gateway.gateway_resource_id
   http_methods      = ["POST"]
-  memory_size       = 256
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
   lambda_environment_variables = {
     STAGING_STORE_BUCKET_NAME     = "${terraform.workspace}-${var.staging_store_bucket_name}"

--- a/infrastructure/lambda-data-collection.tf
+++ b/infrastructure/lambda-data-collection.tf
@@ -72,7 +72,6 @@ module "data-collection-lambda" {
   }
   is_gateway_integration_needed = false
   is_invoked_from_gateway       = false
-  memory_size                   = 512
 
   depends_on = [
     module.ndr-app-config,

--- a/infrastructure/lambda-delete-doc-ref.tf
+++ b/infrastructure/lambda-delete-doc-ref.tf
@@ -78,7 +78,6 @@ module "delete-doc-ref-lambda" {
   rest_api_id       = aws_api_gateway_rest_api.ndr_doc_store_api.id
   resource_id       = module.delete-doc-ref-gateway.gateway_resource_id
   http_methods      = ["DELETE"]
-  memory_size       = 256
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
   lambda_environment_variables = {
     APPCONFIG_APPLICATION         = module.ndr-app-config.app_config_application_id

--- a/infrastructure/lambda-document-manifest-job.tf
+++ b/infrastructure/lambda-document-manifest-job.tf
@@ -79,7 +79,6 @@ module "document-manifest-job-lambda" {
   rest_api_id       = aws_api_gateway_rest_api.ndr_doc_store_api.id
   resource_id       = module.document-manifest-job-gateway.gateway_resource_id
   http_methods      = ["GET", "POST"]
-  memory_size       = 256
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
   lambda_environment_variables = {
     APPCONFIG_APPLICATION        = module.ndr-app-config.app_config_application_id

--- a/infrastructure/lambda-feature-flags.tf
+++ b/infrastructure/lambda-feature-flags.tf
@@ -76,7 +76,6 @@ module "feature-flags-lambda" {
   http_methods      = ["GET"]
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
 
-  memory_size    = 512
   lambda_timeout = 450
 
   lambda_environment_variables = {

--- a/infrastructure/lambda-generate-document-manifest.tf
+++ b/infrastructure/lambda-generate-document-manifest.tf
@@ -46,7 +46,6 @@ module "generate-document-manifest-lambda" {
   handler                  = "handlers.generate_document_manifest_handler.lambda_handler"
   lambda_timeout           = 900
   lambda_ephemeral_storage = 512
-  memory_size              = 512
   iam_role_policies = [
     module.ndr-document-store.s3_object_access_policy,
     module.ndr-lloyd-george-store.s3_object_access_policy,

--- a/infrastructure/lambda-lloyd-george-record-stitch.tf
+++ b/infrastructure/lambda-lloyd-george-record-stitch.tf
@@ -78,7 +78,6 @@ module "lloyd-george-stitch-lambda" {
   resource_id       = module.lloyd-george-stitch-gateway.gateway_resource_id
   http_methods      = ["GET", "POST"]
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
-  memory_size       = 512
   lambda_timeout    = 450
   lambda_environment_variables = {
     APPCONFIG_APPLICATION         = module.ndr-app-config.app_config_application_id

--- a/infrastructure/lambda-login-redirect.tf
+++ b/infrastructure/lambda-login-redirect.tf
@@ -29,7 +29,6 @@ module "login_redirect_lambda" {
   rest_api_id       = aws_api_gateway_rest_api.ndr_doc_store_api.id
   resource_id       = aws_api_gateway_resource.login_resource.id
   http_methods      = ["GET"]
-  memory_size       = 256
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
   lambda_environment_variables = {
     APPCONFIG_APPLICATION   = module.ndr-app-config.app_config_application_id

--- a/infrastructure/lambda-logout.tf
+++ b/infrastructure/lambda-logout.tf
@@ -32,7 +32,6 @@ module "logout_lambda" {
   rest_api_id       = aws_api_gateway_rest_api.ndr_doc_store_api.id
   resource_id       = module.logout-gateway.gateway_resource_id
   http_methods      = ["GET"]
-  memory_size       = 256
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
   lambda_environment_variables = {
     APPCONFIG_APPLICATION          = module.ndr-app-config.app_config_application_id

--- a/infrastructure/lambda-manage-nrl-pointer.tf
+++ b/infrastructure/lambda-manage-nrl-pointer.tf
@@ -12,7 +12,6 @@ module "manage-nrl-pointer-lambda" {
   ]
   rest_api_id       = null
   api_execution_arn = null
-  memory_size       = 512
   lambda_environment_variables = {
     APPCONFIG_APPLICATION   = module.ndr-app-config.app_config_application_id
     APPCONFIG_ENVIRONMENT   = module.ndr-app-config.app_config_environment_id

--- a/infrastructure/lambda-search-doc-references.tf
+++ b/infrastructure/lambda-search-doc-references.tf
@@ -77,7 +77,6 @@ module "search-document-references-lambda" {
   rest_api_id       = aws_api_gateway_rest_api.ndr_doc_store_api.id
   resource_id       = module.search-document-references-gateway.gateway_resource_id
   http_methods      = ["GET"]
-  memory_size       = 256
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
   lambda_environment_variables = {
     APPCONFIG_APPLICATION   = module.ndr-app-config.app_config_application_id

--- a/infrastructure/lambda-statistical-report.tf
+++ b/infrastructure/lambda-statistical-report.tf
@@ -66,7 +66,6 @@ module "statistical-report-lambda" {
   }
   is_gateway_integration_needed = false
   is_invoked_from_gateway       = false
-  memory_size                   = 512
 
   depends_on = [
     module.ndr-app-config,

--- a/infrastructure/lambda-update-upload-state.tf
+++ b/infrastructure/lambda-update-upload-state.tf
@@ -76,7 +76,6 @@ module "update-upload-state-lambda" {
   rest_api_id       = aws_api_gateway_rest_api.ndr_doc_store_api.id
   resource_id       = module.update-upload-state-gateway.gateway_resource_id
   http_methods      = ["POST"]
-  memory_size       = 256
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
   lambda_environment_variables = {
     APPCONFIG_APPLICATION        = module.ndr-app-config.app_config_application_id

--- a/infrastructure/lambda-upload-confirm-result.tf
+++ b/infrastructure/lambda-upload-confirm-result.tf
@@ -78,7 +78,6 @@ module "upload_confirm_result_lambda" {
   rest_api_id       = aws_api_gateway_rest_api.ndr_doc_store_api.id
   resource_id       = module.upload_confirm_result_gateway.gateway_resource_id
   http_methods      = ["POST"]
-  memory_size       = 256
   api_execution_arn = aws_api_gateway_rest_api.ndr_doc_store_api.execution_arn
   lambda_environment_variables = {
     APPCONFIG_APPLICATION        = module.ndr-app-config.app_config_application_id

--- a/infrastructure/lambda-virus-scan-result.tf
+++ b/infrastructure/lambda-virus-scan-result.tf
@@ -66,7 +66,6 @@ module "virus_scan_result_lambda" {
   source      = "./modules/lambda"
   name        = "VirusScanResult"
   handler     = "handlers.virus_scan_result_handler.lambda_handler"
-  memory_size = 256
   iam_role_policies = [
     module.ndr-bulk-staging-store.s3_object_access_policy,
     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",

--- a/infrastructure/lambda-virus-scan-result.tf
+++ b/infrastructure/lambda-virus-scan-result.tf
@@ -63,9 +63,9 @@ module "virus_scan_result_alarm_topic" {
 }
 
 module "virus_scan_result_lambda" {
-  source      = "./modules/lambda"
-  name        = "VirusScanResult"
-  handler     = "handlers.virus_scan_result_handler.lambda_handler"
+  source  = "./modules/lambda"
+  name    = "VirusScanResult"
+  handler = "handlers.virus_scan_result_handler.lambda_handler"
   iam_role_policies = [
     module.ndr-bulk-staging-store.s3_object_access_policy,
     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",

--- a/infrastructure/modules/lambda/README.md
+++ b/infrastructure/modules/lambda/README.md
@@ -38,7 +38,7 @@ No modules.
 | <a name="input_lambda_environment_variables"></a> [lambda\_environment\_variables](#input\_lambda\_environment\_variables) | n/a | `map(string)` | `{}` | no |
 | <a name="input_lambda_ephemeral_storage"></a> [lambda\_ephemeral\_storage](#input\_lambda\_ephemeral\_storage) | n/a | `number` | `512` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | n/a | `number` | `30` | no |
-| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | n/a | `number` | `128` | no |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | n/a | `number` | `512` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The number of concurrent execution allowed for lambda. A value of 0 will stop lambda from running, and -1 removes any concurrency limitations. Default to -1. | `number` | `-1` | no |
 | <a name="input_resource_id"></a> [resource\_id](#input\_resource\_id) | n/a | `string` | `""` | no |

--- a/infrastructure/modules/lambda/variable.tf
+++ b/infrastructure/modules/lambda/variable.tf
@@ -57,7 +57,7 @@ variable "lambda_ephemeral_storage" {
 
 variable "memory_size" {
   type    = number
-  default = 128
+  default = 512
 }
 
 variable "reserved_concurrent_executions" {


### PR DESCRIPTION
- Updated default Lambda memory from 128MB -> 512MB
- Removed all references in the code where a Lambda's `memory_size` <= 512