### PR TITLE
[PRMP-1420] Re-enable DataCollection/StatisticalReport lambdas

### DIFF
--- a/infrastructure/lambda-data-collection.tf
+++ b/infrastructure/lambda-data-collection.tf
@@ -41,10 +41,12 @@ module "data-collection-alarm-topic" {
 }
 
 module "data-collection-lambda" {
-  source         = "./modules/lambda"
-  name           = "DataCollectionLambda"
-  handler        = "handlers.data_collection_handler.lambda_handler"
-  lambda_timeout = 900
+  source                   = "./modules/lambda"
+  name                     = "DataCollectionLambda"
+  handler                  = "handlers.data_collection_handler.lambda_handler"
+  lambda_timeout           = 900
+  lambda_ephemeral_storage = 10240
+  memory_size              = 10240
   iam_role_policy_documents = [
     module.ndr-app-config.app_config_policy,
     module.statistics_dynamodb_table.dynamodb_read_policy_document,

--- a/infrastructure/lambda-data-collection.tf
+++ b/infrastructure/lambda-data-collection.tf
@@ -45,8 +45,8 @@ module "data-collection-lambda" {
   name                     = "DataCollectionLambda"
   handler                  = "handlers.data_collection_handler.lambda_handler"
   lambda_timeout           = 900
-  lambda_ephemeral_storage = 10240
-  memory_size              = 10240
+  lambda_ephemeral_storage = local.is_production ? 10240 : 1769
+  memory_size              = local.is_production ? 10240 : 1769
   iam_role_policy_documents = [
     module.ndr-app-config.app_config_policy,
     module.statistics_dynamodb_table.dynamodb_read_policy_document,

--- a/infrastructure/lambda-statistical-report.tf
+++ b/infrastructure/lambda-statistical-report.tf
@@ -41,10 +41,12 @@ module "statistical-report-alarm-topic" {
 }
 
 module "statistical-report-lambda" {
-  source         = "./modules/lambda"
-  name           = "StatisticalReportLambda"
-  handler        = "handlers.statistical_report_handler.lambda_handler"
-  lambda_timeout = 900
+  source                   = "./modules/lambda"
+  name                     = "StatisticalReportLambda"
+  handler                  = "handlers.statistical_report_handler.lambda_handler"
+  lambda_timeout           = 900
+  lambda_ephemeral_storage = 10240
+  memory_size              = 10240
   iam_role_policy_documents = [
     module.ndr-app-config.app_config_policy,
     module.statistics_dynamodb_table.dynamodb_read_policy_document,

--- a/infrastructure/lambda-statistical-report.tf
+++ b/infrastructure/lambda-statistical-report.tf
@@ -45,8 +45,8 @@ module "statistical-report-lambda" {
   name                     = "StatisticalReportLambda"
   handler                  = "handlers.statistical_report_handler.lambda_handler"
   lambda_timeout           = 900
-  lambda_ephemeral_storage = 10240
-  memory_size              = 10240
+  lambda_ephemeral_storage = local.is_production ? 10240 : 1769
+  memory_size              = local.is_production ? 10240 : 1769
   iam_role_policy_documents = [
     module.ndr-app-config.app_config_policy,
     module.statistics_dynamodb_table.dynamodb_read_policy_document,

--- a/infrastructure/schedules.tf
+++ b/infrastructure/schedules.tf
@@ -57,6 +57,64 @@ resource "aws_lambda_permission" "bulk_upload_report_schedule_permission" {
   ]
 }
 
+resource "aws_cloudwatch_event_rule" "data_collection_schedule" {
+  name                = "${terraform.workspace}_data_collection_schedule"
+  description         = "Schedule for Data Collection Lambda"
+  schedule_expression = "cron(0 20 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "data_collection_schedule_event" {
+  rule      = aws_cloudwatch_event_rule.data_collection_schedule.name
+  target_id = "data_collection_schedule"
+
+  arn = module.data-collection-lambda.lambda_arn
+  depends_on = [
+    module.data-collection-lambda,
+    aws_cloudwatch_event_rule.data_collection_schedule
+  ]
+}
+
+resource "aws_lambda_permission" "data_collection_schedule_permission" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = module.data-collection-lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.data_collection_schedule.arn
+  depends_on = [
+    module.data-collection-lambda,
+    aws_cloudwatch_event_rule.data_collection_schedule
+  ]
+}
+
+resource "aws_cloudwatch_event_rule" "statistical_report_schedule" {
+  name                = "${terraform.workspace}_statistical_report_schedule"
+  description         = "Schedule for Statistical Report Lambda"
+  schedule_expression = "cron(0 8 ? * 2 *)"
+}
+
+resource "aws_cloudwatch_event_target" "statistical_report_schedule_event" {
+  rule      = aws_cloudwatch_event_rule.statistical_report_schedule.name
+  target_id = "statistical_report_schedule"
+
+  arn = module.statistical-report-lambda.lambda_arn
+  depends_on = [
+    module.statistical-report-lambda,
+    aws_cloudwatch_event_rule.statistical_report_schedule
+  ]
+}
+
+resource "aws_lambda_permission" "statistical_report_schedule_permission" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = module.statistical-report-lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.statistical_report_schedule.arn
+  depends_on = [
+    module.statistical-report-lambda,
+    aws_cloudwatch_event_rule.statistical_report_schedule
+  ]
+}
+
 resource "aws_scheduler_schedule" "ods_weekly_update_ecs" {
   count       = local.is_sandbox ? 0 : 1
   name_prefix = "${terraform.workspace}_ods_weekly_update_ecs"

--- a/infrastructure/schedules.tf
+++ b/infrastructure/schedules.tf
@@ -60,7 +60,7 @@ resource "aws_lambda_permission" "bulk_upload_report_schedule_permission" {
 resource "aws_cloudwatch_event_rule" "data_collection_schedule" {
   name                = "${terraform.workspace}_data_collection_schedule"
   description         = "Schedule for Data Collection Lambda"
-  schedule_expression = "cron(0 20 * * ? *)"
+  schedule_expression = "cron(0 20 ? * SAT *)"
 }
 
 resource "aws_cloudwatch_event_target" "data_collection_schedule_event" {

--- a/infrastructure/schedules.tf
+++ b/infrastructure/schedules.tf
@@ -89,7 +89,7 @@ resource "aws_lambda_permission" "data_collection_schedule_permission" {
 resource "aws_cloudwatch_event_rule" "statistical_report_schedule" {
   name                = "${terraform.workspace}_statistical_report_schedule"
   description         = "Schedule for Statistical Report Lambda"
-  schedule_expression = "cron(0 8 ? * 2 *)"
+  schedule_expression = "cron(0 8 ? * MON *)"
 }
 
 resource "aws_cloudwatch_event_target" "statistical_report_schedule_event" {


### PR DESCRIPTION
- Re-enable schedules for both DataCollectionLambda and StatisticalReportLambda
- Set ephemeral storage and memory size to 10240MB