### PR TITLE
[NDR-13] WAF ACL for CloudFront resources

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.70.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -8,7 +8,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.86.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.95.0 |
 
 ## Modules
 
@@ -39,8 +39,9 @@
 | <a name="module_bulk-upload-report-alarm-topic"></a> [bulk-upload-report-alarm-topic](#module\_bulk-upload-report-alarm-topic) | ./modules/sns | n/a |
 | <a name="module_bulk-upload-report-lambda"></a> [bulk-upload-report-lambda](#module\_bulk-upload-report-lambda) | ./modules/lambda | n/a |
 | <a name="module_bulk_upload_report_dynamodb_table"></a> [bulk\_upload\_report\_dynamodb\_table](#module\_bulk\_upload\_report\_dynamodb\_table) | ./modules/dynamo_db | n/a |
-| <a name="module_cloudfront-distribution-lg"></a> [cloudfront-distribution-lg](#module\_cloudfront-distribution-lg) | ./modules/cloudfront/ | n/a |
+| <a name="module_cloudfront-distribution-lg"></a> [cloudfront-distribution-lg](#module\_cloudfront-distribution-lg) | ./modules/cloudfront | n/a |
 | <a name="module_cloudfront_edge_dynamodb_table"></a> [cloudfront\_edge\_dynamodb\_table](#module\_cloudfront\_edge\_dynamodb\_table) | ./modules/dynamo_db | n/a |
+| <a name="module_cloudfront_firewall_waf_v2"></a> [cloudfront\_firewall\_waf\_v2](#module\_cloudfront\_firewall\_waf\_v2) | ./modules/firewall_waf_v2 | n/a |
 | <a name="module_create-doc-ref-gateway"></a> [create-doc-ref-gateway](#module\_create-doc-ref-gateway) | ./modules/gateway | n/a |
 | <a name="module_create-doc-ref-lambda"></a> [create-doc-ref-lambda](#module\_create-doc-ref-lambda) | ./modules/lambda | n/a |
 | <a name="module_create-token-gateway"></a> [create-token-gateway](#module\_create-token-gateway) | ./modules/gateway | n/a |

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -1,11 +1,11 @@
 module "cloudfront_firewall_waf_v2" {
-  source = "./modules/firewall_waf_v2"
+  source         = "./modules/firewall_waf_v2"
   cloudfront_acl = true
 
   environment = var.environment
   owner       = var.owner
   count       = local.is_sandbox ? 0 : 1
-  providers   = {aws = aws.us_east_1}
+  providers   = { aws = aws.us_east_1 }
 }
 
 module "cloudfront-distribution-lg" {

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -1,7 +1,18 @@
+module "cloudfront_firewall_waf_v2" {
+  source = "./modules/firewall_waf_v2"
+  cloudfront_acl = true
+
+  environment = var.environment
+  owner       = var.owner
+  count       = local.is_sandbox ? 0 : 1
+  providers   = {aws = aws.us_east_1}
+}
+
 module "cloudfront-distribution-lg" {
-  source             = "./modules/cloudfront/"
+  source             = "./modules/cloudfront"
   bucket_domain_name = "${terraform.workspace}-${var.lloyd_george_bucket_name}.s3.eu-west-2.amazonaws.com"
   bucket_id          = module.ndr-lloyd-george-store.bucket_id
   qualifed_arn       = module.edge-presign-lambda.qualified_arn
   depends_on         = [module.edge-presign-lambda.qualified_arn, module.ndr-lloyd-george-store.bucket_id, module.ndr-lloyd-george-store.bucket_domain_name]
+  web_acl_id         = try(module.cloudfront_firewall_waf_v2[0].arn, "")
 }

--- a/infrastructure/firewall.tf
+++ b/infrastructure/firewall.tf
@@ -1,5 +1,5 @@
 module "firewall_waf_v2" {
-  source = "./modules/firewall_waf_v2"
+  source         = "./modules/firewall_waf_v2"
   cloudfront_acl = false
 
   environment = var.environment

--- a/infrastructure/firewall.tf
+++ b/infrastructure/firewall.tf
@@ -1,12 +1,10 @@
 module "firewall_waf_v2" {
   source = "./modules/firewall_waf_v2"
+  cloudfront_acl = false
 
   environment = var.environment
   owner       = var.owner
-  count = (terraform.workspace == "ndra" ||
-    terraform.workspace == "ndrb" ||
-    terraform.workspace == "ndrc" ||
-  terraform.workspace == "ndrd") ? 0 : 1
+  count       = local.is_sandbox ? 0 : 1
 }
 
 resource "aws_wafv2_web_acl_association" "web_acl_association" {
@@ -22,3 +20,4 @@ resource "aws_wafv2_web_acl_association" "web_acl_association" {
     module.firewall_waf_v2[0]
   ]
 }
+

--- a/infrastructure/modules/app_config/README.md
+++ b/infrastructure/modules/app_config/README.md
@@ -6,7 +6,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.96.0 |
 
 ## Modules
 

--- a/infrastructure/modules/cloudfront/README.md
+++ b/infrastructure/modules/cloudfront/README.md
@@ -6,7 +6,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.95.0 |
 
 ## Modules
 
@@ -28,6 +28,7 @@ No modules.
 | <a name="input_bucket_domain_name"></a> [bucket\_domain\_name](#input\_bucket\_domain\_name) | Domain name to assign CloudFront distribution to | `string` | n/a | yes |
 | <a name="input_bucket_id"></a> [bucket\_id](#input\_bucket\_id) | Bucket ID to assign CloudFront distribution to | `string` | n/a | yes |
 | <a name="input_qualifed_arn"></a> [qualifed\_arn](#input\_qualifed\_arn) | Lambda@Edge function association | `string` | n/a | yes |
+| <a name="input_web_acl_id"></a> [web\_acl\_id](#input\_web\_acl\_id) | Web ACL to associate this Cloudfront distribution with | `string` | n/a | yes |
 
 ## Outputs
 

--- a/infrastructure/modules/cloudfront/main.tf
+++ b/infrastructure/modules/cloudfront/main.tf
@@ -36,6 +36,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       locations        = ["GB"]
     }
   }
+  web_acl_id = var.web_acl_id
 }
 
 resource "aws_cloudfront_origin_request_policy" "viewer_policy" {
@@ -91,3 +92,4 @@ resource "aws_cloudfront_cache_policy" "nocache" {
     }
   }
 }
+

--- a/infrastructure/modules/cloudfront/variable.tf
+++ b/infrastructure/modules/cloudfront/variable.tf
@@ -16,5 +16,6 @@ variable "qualifed_arn" {
 variable "web_acl_id" {
   type        = string
   description = "Web ACL to associate this Cloudfront distribution with"
+  default     = ""
 }
 

--- a/infrastructure/modules/cloudfront/variable.tf
+++ b/infrastructure/modules/cloudfront/variable.tf
@@ -12,3 +12,9 @@ variable "qualifed_arn" {
   type        = string
   description = "Lambda@Edge function association"
 }
+
+variable "web_acl_id" {
+  type        = string
+  description = "Web ACL to associate this Cloudfront distribution with"
+}
+

--- a/infrastructure/modules/firewall_waf_v2/README.md
+++ b/infrastructure/modules/firewall_waf_v2/README.md
@@ -6,7 +6,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.95.0 |
 
 ## Modules
 
@@ -25,6 +25,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cloudfront_acl"></a> [cloudfront\_acl](#input\_cloudfront\_acl) | n/a | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `string` | n/a | yes |
 | <a name="input_owner"></a> [owner](#input\_owner) | n/a | `string` | n/a | yes |
 

--- a/infrastructure/modules/firewall_waf_v2/main.tf
+++ b/infrastructure/modules/firewall_waf_v2/main.tf
@@ -1,5 +1,5 @@
 resource "aws_wafv2_web_acl" "waf_v2_acl" {
-  name = "${terraform.workspace}-${var.cloudfront_acl ? "cloudwatch" : ""}-fw-waf-v2"
+  name        = "${terraform.workspace}-${var.cloudfront_acl ? "cloudwatch" : ""}-fw-waf-v2"
   description = "A WAF to secure the Repo application."
   scope       = var.cloudfront_acl ? "CLOUDFRONT" : "REGIONAL"
 

--- a/infrastructure/modules/firewall_waf_v2/main.tf
+++ b/infrastructure/modules/firewall_waf_v2/main.tf
@@ -1,7 +1,7 @@
 resource "aws_wafv2_web_acl" "waf_v2_acl" {
-  name        = "${terraform.workspace}-fw-waf-v2"
+  name = "${terraform.workspace}-${var.cloudfront_acl ? "cloudwatch" : ""}-fw-waf-v2"
   description = "A WAF to secure the Repo application."
-  scope       = "REGIONAL"
+  scope       = var.cloudfront_acl ? "CLOUDFRONT" : "REGIONAL"
 
   default_action {
     allow {}
@@ -50,6 +50,9 @@ resource "aws_wafv2_web_acl" "waf_v2_acl" {
             for_each = rule.value["excluded_rules"]
             content {
               name = excluded_rule.value
+              action_to_use {
+                allow {}
+              }
             }
           }
 
@@ -98,3 +101,4 @@ resource "aws_wafv2_web_acl" "waf_v2_acl" {
     Workspace   = terraform.workspace
   }
 }
+

--- a/infrastructure/modules/firewall_waf_v2/main.tf
+++ b/infrastructure/modules/firewall_waf_v2/main.tf
@@ -1,5 +1,5 @@
 resource "aws_wafv2_web_acl" "waf_v2_acl" {
-  name        = "${terraform.workspace}-${var.cloudfront_acl ? "cloudwatch" : ""}-fw-waf-v2"
+  name        = "${terraform.workspace}-${var.cloudfront_acl ? "cloudfront" : ""}-fw-waf-v2"
   description = "A WAF to secure the Repo application."
   scope       = var.cloudfront_acl ? "CLOUDFRONT" : "REGIONAL"
 

--- a/infrastructure/modules/firewall_waf_v2/regex.tf
+++ b/infrastructure/modules/firewall_waf_v2/regex.tf
@@ -1,7 +1,7 @@
 resource "aws_wafv2_regex_pattern_set" "large_body_uri" {
   name        = "${terraform.workspace}-fw-waf-body-size"
   description = "A set of regex to allow specific pages to bypass the large body check"
-  scope       = "REGIONAL"
+  scope       = var.cloudfront_acl ? "CLOUDFRONT" : "REGIONAL"
 
   # Allow pages involving images
   regular_expression {
@@ -24,7 +24,7 @@ resource "aws_wafv2_regex_pattern_set" "large_body_uri" {
 resource "aws_wafv2_regex_pattern_set" "xss_body_uri" {
   name        = "${terraform.workspace}-fw-waf-body-xss"
   description = "A regex to allow specific pages to bypass XSS checks on body"
-  scope       = "REGIONAL"
+  scope       = var.cloudfront_acl ? "CLOUDFRONT" : "REGIONAL"
 
   # Allow pages involving images
   regular_expression {
@@ -42,7 +42,7 @@ resource "aws_wafv2_regex_pattern_set" "xss_body_uri" {
 resource "aws_wafv2_regex_pattern_set" "exclude_cms_uri" {
   name        = "${terraform.workspace}-fw-waf-cms-exclude"
   description = "A regex to allow CMS calls to bypass firewalls"
-  scope       = "REGIONAL"
+  scope       = var.cloudfront_acl ? "CLOUDFRONT" : "REGIONAL"
 
   # Allow pages involving images
   regular_expression {

--- a/infrastructure/modules/firewall_waf_v2/variables.tf
+++ b/infrastructure/modules/firewall_waf_v2/variables.tf
@@ -5,3 +5,8 @@ variable "environment" {
 variable "owner" {
   type = string
 }
+
+variable "cloudfront_acl" {
+  type = bool
+}
+


### PR DESCRIPTION
This adds a WAF to Cloudfront

Notes

- Had to duplicate the firewall, as they need to be configured for "CLOUDFRONT" and "REGIONAL"
- Make it so that the implementation of the firewall checks `locals.is_sandbox`
- There was an error in my IDE around the usage of the `action_to_use`, now explicitly only allow upon exclusions, no danger here as there are no exclusions configured anyway.
