### PR TITLE
[PRMT-439] - Remove workflow calls for lambda and ui deployment on ndr-test

### DIFF
--- a/.github/workflows/terraform-deploy-to-test-manual.yml
+++ b/.github/workflows/terraform-deploy-to-test-manual.yml
@@ -71,27 +71,3 @@ jobs:
     - name: Terraform Apply 
       run: terraform apply -auto-approve -input=false tf.plan
       working-directory: ./infrastructure
-  
-  run_main_repo_deploy_lambdas:
-    name: Deploy Lambdas on NDR Functional Repo
-    needs: ['terraform_process']
-    uses: nhsconnect/national-document-repository/.github/workflows/lambdas-deploy-feature-to-sandbox.yml@main
-    with:
-      build_branch: main
-      sandbox: ndr-test
-      environment: test
-    secrets:
-      AWS_ASSUME_ROLE: ${{ secrets.AWS_ASSUME_ROLE }}
-  
-  run_main_repo_deploy_ui:
-    name: Deploy Lambdas on NDR Functional Repo
-    needs: ['terraform_process']
-    uses: nhsconnect/national-document-repository/.github/workflows/ui-deploy-feature-to-sandbox-manual.yml@main
-    with:
-      build_branch: main
-      sandbox: ndr-test
-      environment: test
-    secrets:
-      AWS_ASSUME_ROLE: ${{ secrets.AWS_ASSUME_ROLE }}
-        
-        


### PR DESCRIPTION
After discussion with @bethany-kish-nhs and @robg-nhs on the back of workflow failures, we are removing workflow calls for the lambda and ui deployment on ndr-test from the infrastructure workflow. The lambdas and UI will be manually deployed by running the ndr repo's existing workflow for ndr-test.