### PR TITLE
[NDR-198] Manage AWS lambda layers after lambda has been destroyed

### DIFF
--- a/.github/workflows/terraform-deploy-feature-to-sandbox.yml
+++ b/.github/workflows/terraform-deploy-feature-to-sandbox.yml
@@ -98,6 +98,12 @@ jobs:
         working-directory: ./infrastructure
         shell: bash
 
+      - name: Lambda Layer Imports
+        id: lambda_layer_import
+        run: ./import_lambda_layers.sh ${{ github.event.inputs.sandboxWorkspace }} ${{ vars.TF_VARS_FILE }}
+        working-directory: ./scripts
+        shell: bash
+
       - name: Terraform Plan
         id: plan
         run: |

--- a/.github/workflows/terraform-deploy-feature-to-sandbox.yml
+++ b/.github/workflows/terraform-deploy-feature-to-sandbox.yml
@@ -65,6 +65,12 @@ jobs:
         working-directory: ./infrastructure
         shell: bash
 
+      - name: Lambda Layer Imports
+        id: lambda_layer_import
+        run: ./import_lambda_layers.sh ${{ github.event.inputs.sandboxWorkspace }} ${{ vars.TF_VARS_FILE }}
+        working-directory: ./scripts
+        shell: bash
+
       - name: Terraform Plan Base
         id: base_plan
         run: |
@@ -96,12 +102,6 @@ jobs:
         id: workspace
         run: terraform workspace select ${{ github.event.inputs.sandboxWorkspace}}
         working-directory: ./infrastructure
-        shell: bash
-
-      - name: Lambda Layer Imports
-        id: lambda_layer_import
-        run: ./import_lambda_layers.sh ${{ github.event.inputs.sandboxWorkspace }} ${{ vars.TF_VARS_FILE }}
-        working-directory: ./scripts
         shell: bash
 
       - name: Terraform Plan

--- a/.github/workflows/terraform-deploy-feature-to-sandbox.yml
+++ b/.github/workflows/terraform-deploy-feature-to-sandbox.yml
@@ -65,12 +65,6 @@ jobs:
         working-directory: ./infrastructure
         shell: bash
 
-      - name: Lambda Layer Imports
-        id: lambda_layer_import
-        run: ./import_lambda_layers.sh ${{ github.event.inputs.sandboxWorkspace }} ${{ vars.TF_VARS_FILE }}
-        working-directory: ./scripts
-        shell: bash
-
       - name: Terraform Plan Base
         id: base_plan
         run: |
@@ -102,6 +96,12 @@ jobs:
         id: workspace
         run: terraform workspace select ${{ github.event.inputs.sandboxWorkspace}}
         working-directory: ./infrastructure
+        shell: bash
+
+      - name: Lambda Layer Imports
+        id: lambda_layer_import
+        run: ./import_lambda_layers.sh ${{ github.event.inputs.sandboxWorkspace }} ${{ vars.TF_VARS_FILE }}
+        working-directory: ./scripts
         shell: bash
 
       - name: Terraform Plan

--- a/.github/workflows/terraform-deploy-to-perf-manual.yml
+++ b/.github/workflows/terraform-deploy-to-perf-manual.yml
@@ -1,5 +1,5 @@
 # .github/workflows/terraform-dev
-name: 'Deploy Feature Branch to Perf'
+name: "Deploy Feature Branch to Perf"
 
 on:
   workflow_dispatch:
@@ -12,64 +12,68 @@ on:
 permissions:
   pull-requests: write
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-    
+  contents: read # This is required for actions/checkout
+
 jobs:
   terraform_process:
     runs-on: ubuntu-latest
     environment: perf
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.inputs.buildBranch}}
-        fetch-depth: '0'
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.buildBranch}}
+          fetch-depth: "0"
 
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
-        role-skip-session-tagging: true
-        aws-region: ${{ vars.AWS_REGION }}
-        mask-aws-account-id: true
-      
-    - name: View AWS Role
-      run: aws sts get-caller-identity
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-skip-session-tagging: true
+          aws-region: ${{ vars.AWS_REGION }}
+          mask-aws-account-id: true
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.11.4
-        terraform_wrapper: false
-      
-    - name: Terraform Init
-      id: init
-      run: terraform init -backend-config=backend.conf
-      working-directory: ./infrastructure 
-      shell: bash
+      - name: View AWS Role
+        run: aws sts get-caller-identity
 
-    - name: Terraform Set Workspace
-      id: workspace
-      run:  terraform workspace select ${{ secrets.AWS_WORKSPACE }}
-      working-directory: ./infrastructure 
-      shell: bash
-      
-      # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check
+      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.4
+          terraform_wrapper: false
 
-    - name: Terraform Plan
-      id: plan
-      run: |
-        terraform plan -input=false -no-color -var-file="${{vars.TF_VARS_FILE}}" -out tf.plan
-      working-directory: ./infrastructure
-      shell: bash
+      - name: Terraform Init
+        id: init
+        run: terraform init -backend-config=backend.conf
+        working-directory: ./infrastructure
+        shell: bash
 
-    - name: Terraform Apply 
-      run: terraform apply -auto-approve -input=false tf.plan
-      working-directory: ./infrastructure
-        
-        
+      - name: Terraform Set Workspace
+        id: workspace
+        run: terraform workspace select ${{ secrets.AWS_WORKSPACE }}
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Lambda Layer Imports
+        id: lambda_layer_import
+        run: ./import_lambda_layers.sh ${{ secrets.AWS_WORKSPACE }} ${{ vars.TF_VARS_FILE }}
+        working-directory: ./scripts
+        shell: bash
+
+        # Checks that all Terraform configuration files adhere to a canonical format
+      - name: Terraform Format
+        run: terraform fmt -check
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -input=false -no-color -var-file="${{vars.TF_VARS_FILE}}" -out tf.plan
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve -input=false tf.plan
+        working-directory: ./infrastructure

--- a/.github/workflows/terraform-deploy-to-pre-prod-manual.yml
+++ b/.github/workflows/terraform-deploy-to-pre-prod-manual.yml
@@ -1,4 +1,4 @@
-name: 'Deploy to Pre-Prod'
+name: "Deploy to Pre-Prod"
 
 on:
   workflow_dispatch:
@@ -12,8 +12,8 @@ on:
 permissions:
   pull-requests: write
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-    
+  contents: read # This is required for actions/checkout
+
 jobs:
   tag_and_release:
     runs-on: ubuntu-latest
@@ -22,75 +22,81 @@ jobs:
     permissions: write-all
 
     steps:
-    - name: Checkout main
-      if: ${{ github.event.inputs.branch_or_tag == 'main' }}
-      uses: actions/checkout@v5
-      with:
-        ref: main
-        fetch-depth: '0'
+      - name: Checkout main
+        if: ${{ github.event.inputs.branch_or_tag == 'main' }}
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: "0"
 
-    - name: Bump version and push tag
-      if: ${{ github.event.inputs.branch_or_tag == 'main' }}
-      id: versioning
-      uses: anothrNick/github-tag-action@1.64.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: false
-        DEFAULT_BUMP: patch
+      - name: Bump version and push tag
+        if: ${{ github.event.inputs.branch_or_tag == 'main' }}
+        id: versioning
+        uses: anothrNick/github-tag-action@1.64.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: false
+          DEFAULT_BUMP: patch
 
-    - name: View outputs
-      run: |
-        echo Deploying branch or tagged version to pre-prod: ${{ steps.versioning.outputs.tag || github.event.inputs.branch_or_tag }}
+      - name: View outputs
+        run: |
+          echo Deploying branch or tagged version to pre-prod: ${{ steps.versioning.outputs.tag || github.event.inputs.branch_or_tag }}
 
   terraform_process:
     runs-on: ubuntu-latest
-    needs: ['tag_and_release']
+    needs: ["tag_and_release"]
     environment: pre-prod
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v5
-      with:
-        ref: ${{needs.tag_and_release.outputs.version}}
-        fetch-depth: '0'
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{needs.tag_and_release.outputs.version}}
+          fetch-depth: "0"
 
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
-        role-skip-session-tagging: true
-        aws-region: ${{ vars.AWS_REGION }}
-        mask-aws-account-id: true
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-skip-session-tagging: true
+          aws-region: ${{ vars.AWS_REGION }}
+          mask-aws-account-id: true
 
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.11.4
-        terraform_wrapper: false
-      
-    - name: Terraform Init
-      id: init
-      run: terraform init -backend-config=backend-pre-prod.conf
-      working-directory: ./infrastructure 
-      shell: bash
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.4
+          terraform_wrapper: false
 
-    - name: Terraform Set Workspace
-      id: workspace
-      run:  terraform workspace select ${{ secrets.AWS_WORKSPACE }}
-      working-directory: ./infrastructure 
-      shell: bash
+      - name: Terraform Init
+        id: init
+        run: terraform init -backend-config=backend-pre-prod.conf
+        working-directory: ./infrastructure
+        shell: bash
 
-    - name: Terraform Format
-      run: terraform fmt -check
-      working-directory: ./infrastructure 
+      - name: Terraform Set Workspace
+        id: workspace
+        run: terraform workspace select ${{ secrets.AWS_WORKSPACE }}
+        working-directory: ./infrastructure
+        shell: bash
 
-    - name: Terraform Plan
-      id: plan
-      run: |
-        terraform plan -input=false -no-color -var-file="${{vars.TF_VARS_FILE}}" -out tf.plan
-      working-directory: ./infrastructure
-      shell: bash
-    
-    - name: Terraform Apply 
-      run: terraform apply -auto-approve -input=false tf.plan
-      working-directory: ./infrastructure
+      - name: Lambda Layer Imports
+        id: lambda_layer_import
+        run: ./import_lambda_layers.sh ${{ secrets.AWS_WORKSPACE }} ${{ vars.TF_VARS_FILE }}
+        working-directory: ./scripts
+        shell: bash
+
+      - name: Terraform Format
+        run: terraform fmt -check
+        working-directory: ./infrastructure
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -input=false -no-color -var-file="${{vars.TF_VARS_FILE}}" -out tf.plan
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve -input=false tf.plan
+        working-directory: ./infrastructure

--- a/.github/workflows/terraform-deploy-to-prod-manual.yml
+++ b/.github/workflows/terraform-deploy-to-prod-manual.yml
@@ -1,5 +1,5 @@
 # .github/workflows/terraform-dev
-name: 'Deploy tagged version to Prod'
+name: "Deploy tagged version to Prod"
 
 on:
   workflow_dispatch:
@@ -12,65 +12,69 @@ on:
 permissions:
   pull-requests: write
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-    
+  contents: read # This is required for actions/checkout
+
 jobs:
   terraform_process:
     runs-on: ubuntu-latest
     environment: prod
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.inputs.tagVersion}}
-        fetch-depth: '0'
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tagVersion}}
+          fetch-depth: "0"
 
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
-        role-skip-session-tagging: true
-        aws-region: ${{ vars.AWS_REGION }}
-        mask-aws-account-id: true
-      
-    - name: View AWS Role
-      run: aws sts get-caller-identity
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-skip-session-tagging: true
+          aws-region: ${{ vars.AWS_REGION }}
+          mask-aws-account-id: true
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.11.4
-        terraform_wrapper: false
-      
-    - name: Terraform Init
-      id: init
-      run: terraform init -backend-config=backend-prod.conf
-      working-directory: ./infrastructure 
-      shell: bash
+      - name: View AWS Role
+        run: aws sts get-caller-identity
 
-    - name: Terraform Set Workspace
-      id: workspace
-      run:  terraform workspace select ${{ secrets.AWS_WORKSPACE }}
-      working-directory: ./infrastructure 
-      shell: bash
-      
-      # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check
-      working-directory: ./infrastructure 
+      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.4
+          terraform_wrapper: false
 
-    - name: Terraform Plan
-      id: plan
-      run: |
-        terraform plan -input=false -no-color -var-file="${{vars.TF_VARS_FILE}}" -out tf.plan
-      working-directory: ./infrastructure
-      shell: bash
-    
-    - name: Terraform Apply 
-      run: terraform apply -auto-approve -input=false tf.plan
-      working-directory: ./infrastructure
-        
-        
+      - name: Terraform Init
+        id: init
+        run: terraform init -backend-config=backend-prod.conf
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Terraform Set Workspace
+        id: workspace
+        run: terraform workspace select ${{ secrets.AWS_WORKSPACE }}
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Lambda Layer Imports
+        id: lambda_layer_import
+        run: ./import_lambda_layers.sh ${{ secrets.AWS_WORKSPACE }} ${{ vars.TF_VARS_FILE }}
+        working-directory: ./scripts
+        shell: bash
+
+        # Checks that all Terraform configuration files adhere to a canonical format
+      - name: Terraform Format
+        run: terraform fmt -check
+        working-directory: ./infrastructure
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -input=false -no-color -var-file="${{vars.TF_VARS_FILE}}" -out tf.plan
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve -input=false tf.plan
+        working-directory: ./infrastructure

--- a/.github/workflows/terraform-deploy-to-test-manual.yml
+++ b/.github/workflows/terraform-deploy-to-test-manual.yml
@@ -1,5 +1,5 @@
 # .github/workflows/terraform-dev
-name: 'Deploy Feature Branch to Test'
+name: "Deploy Feature Branch to Test"
 
 on:
   workflow_dispatch:
@@ -12,62 +12,68 @@ on:
 permissions:
   pull-requests: write
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-    
+  contents: read # This is required for actions/checkout
+
 jobs:
   terraform_process:
     runs-on: ubuntu-latest
     environment: test
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.inputs.build_branch}}
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.build_branch}}
 
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
-        role-skip-session-tagging: true
-        aws-region: ${{ vars.AWS_REGION }}
-        mask-aws-account-id: true
-      
-    - name: View AWS Role
-      run: aws sts get-caller-identity
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-skip-session-tagging: true
+          aws-region: ${{ vars.AWS_REGION }}
+          mask-aws-account-id: true
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.11.4
-        terraform_wrapper: false
-      
-    - name: Terraform Init
-      id: init
-      run: terraform init -backend-config=backend-test.conf
-      working-directory: ./infrastructure 
-      shell: bash
+      - name: View AWS Role
+        run: aws sts get-caller-identity
 
-    - name: Terraform Set Workspace
-      id: workspace
-      run:  terraform workspace select -or-create ${{ secrets.AWS_WORKSPACE }}
-      working-directory: ./infrastructure 
-      shell: bash
-      
-      # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check
-      working-directory: ./infrastructure 
+      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.4
+          terraform_wrapper: false
 
-    - name: Terraform Plan
-      id: plan
-      run: |
-        terraform plan -input=false -no-color -var-file="${{vars.TF_VARS_FILE}}" -out tf.plan
-      working-directory: ./infrastructure
-      shell: bash
-    
-    - name: Terraform Apply 
-      run: terraform apply -auto-approve -input=false tf.plan
-      working-directory: ./infrastructure
+      - name: Terraform Init
+        id: init
+        run: terraform init -backend-config=backend-test.conf
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Terraform Set Workspace
+        id: workspace
+        run: terraform workspace select -or-create ${{ secrets.AWS_WORKSPACE }}
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Lambda Layer Imports
+        id: lambda_layer_import
+        run: ./import_lambda_layers.sh ${{ secrets.AWS_WORKSPACE }} ${{ vars.TF_VARS_FILE }}
+        working-directory: ./scripts
+        shell: bash
+
+        # Checks that all Terraform configuration files adhere to a canonical format
+      - name: Terraform Format
+        run: terraform fmt -check
+        working-directory: ./infrastructure
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -input=false -no-color -var-file="${{vars.TF_VARS_FILE}}" -out tf.plan
+        working-directory: ./infrastructure
+        shell: bash
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve -input=false tf.plan
+        working-directory: ./infrastructure

--- a/infrastructure/lambda-layers.tf
+++ b/infrastructure/lambda-layers.tf
@@ -1,23 +1,19 @@
 module "lambda-layer-core" {
   source     = "./modules/lambda_layers"
-  account_id = data.aws_caller_identity.current.account_id
   layer_name = "core"
 }
 
 module "lambda-layer-data" {
   source     = "./modules/lambda_layers"
-  account_id = data.aws_caller_identity.current.account_id
   layer_name = "data"
 }
 
 module "lambda-layer-alerting" {
   source     = "./modules/lambda_layers"
-  account_id = data.aws_caller_identity.current.account_id
   layer_name = "alerting"
 }
 
 module "lambda-layer-reports" {
   source     = "./modules/lambda_layers"
-  account_id = data.aws_caller_identity.current.account_id
   layer_name = "reports"
 }

--- a/infrastructure/lambda-layers.tf
+++ b/infrastructure/lambda-layers.tf
@@ -21,23 +21,3 @@ module "lambda-layer-reports" {
   account_id = data.aws_caller_identity.current.account_id
   layer_name = "reports"
 }
-
-import {
-  to = module.lambda-layer-core.aws_lambda_layer_version.lambda_layer
-  id = "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${terraform.workspace}_core_lambda_layer:3"
-}
-
-import {
-  to = module.lambda-layer-data.aws_lambda_layer_version.lambda_layer
-  id = "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${terraform.workspace}_data_lambda_layer:3"
-}
-
-import {
-  to = module.lambda-layer-alerting.aws_lambda_layer_version.lambda_layer
-  id = "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${terraform.workspace}_alerting_lambda_layer:22"
-}
-
-import {
-  to = module.lambda-layer-reports.aws_lambda_layer_version.lambda_layer
-  id = "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${terraform.workspace}_reports_lambda_layer:1"
-}

--- a/infrastructure/lambda-layers.tf
+++ b/infrastructure/lambda-layers.tf
@@ -16,3 +16,9 @@ module "lambda-layer-alerting" {
   layer_name = "alerting"
 }
 
+module "lambda-layer-reports" {
+  source     = "./modules/lambda_layers"
+  account_id = data.aws_caller_identity.current.account_id
+  layer_name = "reports"
+}
+

--- a/infrastructure/lambda-layers.tf
+++ b/infrastructure/lambda-layers.tf
@@ -22,3 +22,22 @@ module "lambda-layer-reports" {
   layer_name = "reports"
 }
 
+import {
+  to = module.lambda-layer-core.aws_lambda_layer_version.lambda_layer
+  id = "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${terraform.workspace}_core_lambda_layer:3"
+}
+
+import {
+  to = module.lambda-layer-data.aws_lambda_layer_version.lambda_layer
+  id = "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${terraform.workspace}_data_lambda_layer:3"
+}
+
+import {
+  to = module.lambda-layer-alerting.aws_lambda_layer_version.lambda_layer
+  id = "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${terraform.workspace}_alerting_lambda_layer:22"
+}
+
+import {
+  to = module.lambda-layer-reports.aws_lambda_layer_version.lambda_layer
+  id = "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${terraform.workspace}_reports_lambda_layer:1"
+}

--- a/infrastructure/modules/lambda_layers/README.md
+++ b/infrastructure/modules/lambda_layers/README.md
@@ -40,11 +40,11 @@ module "lambda_layer" {
 | [aws_iam_policy.lambda_layer_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_lambda_layer_version.lambda_layer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
 | [archive_file.lambda_layer_placeholder](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID used to generate IAM policy for layer access. | `string` | n/a | yes |
 | <a name="input_layer_name"></a> [layer\_name](#input\_layer\_name) | Logical name assigned to the Lambda layer. | `string` | n/a | yes |
 ## Outputs
 

--- a/infrastructure/modules/lambda_layers/iam.tf
+++ b/infrastructure/modules/lambda_layers/iam.tf
@@ -11,9 +11,10 @@ resource "aws_iam_policy" "lambda_layer_policy" {
           "lambda:ListLayers"
         ],
         Resource = [
-          "arn:aws:lambda:eu-west-2:${var.account_id}:layer:${local.lambda_layer_aws_name}:*"
+          "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:${local.lambda_layer_aws_name}:*"
         ]
       }
     ]
   })
 }
+

--- a/infrastructure/modules/lambda_layers/main.tf
+++ b/infrastructure/modules/lambda_layers/main.tf
@@ -2,6 +2,8 @@ locals {
   lambda_layer_aws_name = "${terraform.workspace}_${var.layer_name}_lambda_layer"
 }
 
+data "aws_caller_identity" "current" {}
+
 data "archive_file" "lambda_layer_placeholder" {
   type        = "zip"
   source_file = "placeholder_lambda.py"

--- a/infrastructure/modules/lambda_layers/variable.tf
+++ b/infrastructure/modules/lambda_layers/variable.tf
@@ -1,8 +1,3 @@
-variable "account_id" {
-  description = "The AWS account ID used to generate IAM policy for layer access."
-  type        = string
-}
-
 variable "layer_name" {
   description = "Logical name assigned to the Lambda layer."
   type        = string

--- a/infrastructure/modules/vpc/main.tf
+++ b/infrastructure/modules/vpc/main.tf
@@ -21,6 +21,7 @@ resource "aws_default_security_group" "default" {
   ingress = []
   egress  = []
   tags = {
+    Name      = "core-sg"
     Workspace = "core"
   }
 }
@@ -28,7 +29,8 @@ resource "aws_default_security_group" "default" {
 data "aws_internet_gateway" "ig" {
   count = local.is_production ? 0 : 1
   tags = {
-    Name = "${var.standalone_vpc_ig_tag}-vpc-internet-gateway"
+    Name      = "${var.standalone_vpc_ig_tag}-vpc-internet-gateway"
+    Workspace = "core"
   }
 }
 
@@ -36,7 +38,8 @@ resource "aws_internet_gateway" "ig" {
   count  = local.is_production ? 1 : 0
   vpc_id = local.is_production ? aws_vpc.vpc[0].id : data.aws_vpc.vpc[0].id
   tags = {
-    Name = "${terraform.workspace}-vpc-internet-gateway"
+    Name      = "${terraform.workspace}-vpc-internet-gateway"
+    Workspace = "core"
   }
 }
 
@@ -46,7 +49,8 @@ resource "aws_vpc_endpoint" "ndr_gateway_vpc_endpoint" {
   service_name    = "com.amazonaws.eu-west-2.${var.endpoint_gateway_services[count.index]}"
   route_table_ids = [aws_route_table.private[0].id]
   tags = {
-    Name = "${terraform.workspace}-${var.endpoint_gateway_services[count.index]}-vpc"
+    Name      = "${terraform.workspace}-${var.endpoint_gateway_services[count.index]}-vpc"
+    Workspace = "core"
   }
 }
 
@@ -60,7 +64,8 @@ resource "aws_vpc_endpoint" "ndr_interface_vpc_endpoint" {
 
   service_name = "com.amazonaws.eu-west-2.${var.endpoint_interface_services[count.index]}"
   tags = {
-    Name = "${terraform.workspace}-${var.endpoint_interface_services[count.index]}-vpc"
+    Name      = "${terraform.workspace}-${var.endpoint_interface_services[count.index]}-vpc"
+    Workspace = "core"
   }
 }
 

--- a/infrastructure/modules/vpc/main.tf
+++ b/infrastructure/modules/vpc/main.tf
@@ -20,17 +20,12 @@ resource "aws_default_security_group" "default" {
   vpc_id  = local.is_production ? aws_vpc.vpc[0].id : data.aws_vpc.vpc[0].id
   ingress = []
   egress  = []
-  tags = {
-    Name      = "core-sg"
-    Workspace = "core"
-  }
 }
 
 data "aws_internet_gateway" "ig" {
   count = local.is_production ? 0 : 1
   tags = {
-    Name      = "${var.standalone_vpc_ig_tag}-vpc-internet-gateway"
-    Workspace = "core"
+    Name = "${var.standalone_vpc_ig_tag}-vpc-internet-gateway"
   }
 }
 
@@ -38,8 +33,7 @@ resource "aws_internet_gateway" "ig" {
   count  = local.is_production ? 1 : 0
   vpc_id = local.is_production ? aws_vpc.vpc[0].id : data.aws_vpc.vpc[0].id
   tags = {
-    Name      = "${terraform.workspace}-vpc-internet-gateway"
-    Workspace = "core"
+    Name = "${terraform.workspace}-vpc-internet-gateway"
   }
 }
 
@@ -49,8 +43,7 @@ resource "aws_vpc_endpoint" "ndr_gateway_vpc_endpoint" {
   service_name    = "com.amazonaws.eu-west-2.${var.endpoint_gateway_services[count.index]}"
   route_table_ids = [aws_route_table.private[0].id]
   tags = {
-    Name      = "${terraform.workspace}-${var.endpoint_gateway_services[count.index]}-vpc"
-    Workspace = "core"
+    Name = "${terraform.workspace}-${var.endpoint_gateway_services[count.index]}-vpc"
   }
 }
 
@@ -64,8 +57,7 @@ resource "aws_vpc_endpoint" "ndr_interface_vpc_endpoint" {
 
   service_name = "com.amazonaws.eu-west-2.${var.endpoint_interface_services[count.index]}"
   tags = {
-    Name      = "${terraform.workspace}-${var.endpoint_interface_services[count.index]}-vpc"
-    Workspace = "core"
+    Name = "${terraform.workspace}-${var.endpoint_interface_services[count.index]}-vpc"
   }
 }
 

--- a/scripts/cleanup_versions.py
+++ b/scripts/cleanup_versions.py
@@ -94,13 +94,12 @@ class CleanupVersions:
             response = self.lambda_client.list_layer_versions(
                 LayerName=layer["LayerName"]
             )
-            print(response)
             versions_to_remove = [
                 layer_version["Version"]
                 for layer_version in response["LayerVersions"][:-1]
             ]
             layer_versions.update({layer["LayerName"]: versions_to_remove})
-            print(layer_versions)
+
         return layer_versions
 
     def delete_lambda_layer_versions(self):

--- a/scripts/import_lambda_layers.sh
+++ b/scripts/import_lambda_layers.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Check for required argument
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <workspace> <vars file>"
+  echo "Example: $0 ndrd dev.tfvars"
+  exit 1
+fi
+
+WORKSPACE="$1"
+TFVARS="$2"
+REGION="eu-west-2"
+
+# Define suffixes and their corresponding Terraform resource paths
+declare -A LAYER_SUFFIX_TO_TF_RESOURCE
+LAYER_SUFFIX_TO_TF_RESOURCE=(
+  ["core"]="module.lambda-layer-core.aws_lambda_layer_version.lambda_layer"
+  ["data"]="module.lambda-layer-data.aws_lambda_layer_version.lambda_layer"
+  ["reports"]="module.lambda-layer-reports.aws_lambda_layer_version.lambda_layer"
+  ["alerting"]="module.lambda-layer-alerting.aws_lambda_layer_version.lambda_layer"
+)
+
+for SUFFIX in "${!LAYER_SUFFIX_TO_TF_RESOURCE[@]}"; do
+  LAYER_NAME="${WORKSPACE}_${SUFFIX}_lambda_layer"
+  TF_RESOURCE="${LAYER_SUFFIX_TO_TF_RESOURCE[$SUFFIX]}"
+
+  echo "🔍 Processing $LAYER_NAME → $TF_RESOURCE"
+
+  # Get the latest version ARN for the layer
+  LAYER_ARN=$(aws lambda list-layer-versions \
+    --layer-name "$LAYER_NAME" \
+    --region "$REGION" \
+    --query 'LayerVersions[0].LayerVersionArn' \
+    --output text)
+
+  if [[ "$LAYER_ARN" == "None" || -z "$LAYER_ARN" ]]; then
+    echo "❌ No versions found for $LAYER_NAME — skipping"
+    continue
+  fi
+
+  echo "✅ Found latest version: $LAYER_ARN"
+
+  # Check if already imported
+  if terraform state list 2>/dev/null | grep -q "$TF_RESOURCE"; then
+    echo "ℹ️  Already imported: $TF_RESOURCE"
+  else
+    echo "📦 Importing..."
+    cd ../infrastructure/
+    terraform import -config=. -var-file="$TFVARS" "$TF_RESOURCE" "$LAYER_ARN"
+  fi
+
+  echo "--------------------------------------------"
+done

--- a/scripts/import_lambda_layers.sh
+++ b/scripts/import_lambda_layers.sh
@@ -48,7 +48,16 @@ for SUFFIX in "${!LAYER_SUFFIX_TO_TF_RESOURCE[@]}"; do
   else
     echo "📦 Importing..."
     cd ../infrastructure/
-    terraform import -config=. -var-file="$TFVARS" "$TF_RESOURCE" "$LAYER_ARN"
+    if terraform state list | grep -q "$TF_RESOURCE"; then
+      echo "ℹ️  Skipping import: $TF_RESOURCE is already managed in state."
+    else
+      echo "📦 Importing $TF_RESOURCE..."
+      if terraform import -config=. -var-file="$TFVARS" "$TF_RESOURCE" "$LAYER_ARN"; then
+        echo "✅ Imported: $TF_RESOURCE"
+      else
+        echo "⚠️  Failed to import: $TF_RESOURCE"
+      fi
+    fi
   fi
 
   echo "--------------------------------------------"


### PR DESCRIPTION
This adds  the reports lambda layer into terraform that had been mistakenly left out.
It also adds an import script as many layers have not been imported into terraform since being created. This import script will move on if the layer doesn't exist or it is already in terraform. if it isn't in terraform it will import it in. 

Once the branch has been fully deployed to all environments we should be able to remove the import step