### PR TITLE
[NDR-211-truststore] Create truststore bucket for CA cert for mTLS

### DIFF
--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -116,6 +116,15 @@ module "ndr-bulk-staging-store" {
   ]
 }
 
+module "ndr-truststore" {
+  source                = "./modules/s3"
+  access_logs_enabled   = local.is_production
+  access_logs_bucket_id = local.access_logs_bucket_id
+  bucket_name           = var.trustore_bucket_name
+  environment           = var.environment
+  owner                 = var.owner
+}
+
 # Lifecycle Rules
 resource "aws_s3_bucket_lifecycle_configuration" "lg-lifecycle-rules" {
   bucket = module.ndr-lloyd-george-store.bucket_id

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -117,12 +117,14 @@ module "ndr-bulk-staging-store" {
 }
 
 module "ndr-truststore" {
-  source                = "./modules/s3"
-  access_logs_enabled   = local.is_production
-  access_logs_bucket_id = local.access_logs_bucket_id
-  bucket_name           = var.truststore_bucket_name
-  environment           = var.environment
-  owner                 = var.owner
+  source                   = "./modules/s3"
+  access_logs_enabled      = local.is_production
+  access_logs_bucket_id    = local.access_logs_bucket_id
+  bucket_name              = var.truststore_bucket_name
+  environment              = var.environment
+  owner                    = var.owner
+  enable_bucket_versioning = true
+  force_destroy            = local.is_force_destroy
 }
 
 # Lifecycle Rules

--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -120,7 +120,7 @@ module "ndr-truststore" {
   source                = "./modules/s3"
   access_logs_enabled   = local.is_production
   access_logs_bucket_id = local.access_logs_bucket_id
-  bucket_name           = var.trustore_bucket_name
+  bucket_name           = var.truststore_bucket_name
   environment           = var.environment
   owner                 = var.owner
 }

--- a/infrastructure/variable.tf
+++ b/infrastructure/variable.tf
@@ -57,7 +57,7 @@ variable "statistical_reports_bucket_name" {
   default     = "statistical-reports"
 }
 
-variable "trustore_bucket_name" {
+variable "truststore_bucket_name" {
   type        = string
   description = "The name of the S3 bucket to store trusted CA's for MTLS"
   default     = "truststore"

--- a/infrastructure/variable.tf
+++ b/infrastructure/variable.tf
@@ -57,6 +57,12 @@ variable "statistical_reports_bucket_name" {
   default     = "statistical-reports"
 }
 
+variable "trustore_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket to store trusted CA's for MTLS"
+  default     = "truststore"
+}
+
 # DynamoDB Table Variables
 
 variable "pdm_dynamodb_table_name" {

--- a/infrastructure/variable.tf
+++ b/infrastructure/variable.tf
@@ -60,7 +60,7 @@ variable "statistical_reports_bucket_name" {
 variable "truststore_bucket_name" {
   type        = string
   description = "The name of the S3 bucket to store trusted CA's for MTLS"
-  default     = "truststore"
+  default     = "ndr-truststore"
 }
 
 # DynamoDB Table Variables


### PR DESCRIPTION
Created NDR Truststore bucket for storing Certificate Authority used to verify identity with mTLS. 

This bucket needs to exist before the API Gateway custom domain can be created, as it needs to point at the cert inside. 