### PR TITLE
[PRME-253] Add missing production logic to CORS policy on S3 buckets

### DIFF
--- a/infrastructure/buckets.tf
+++ b/infrastructure/buckets.tf
@@ -18,13 +18,13 @@ module "ndr-document-store" {
     {
       allowed_headers = ["*"]
       allowed_methods = ["POST", "PUT", "DELETE"]
-      allowed_origins = ["https://${terraform.workspace}.${var.domain}"]
+      allowed_origins = [contains(["prod"], terraform.workspace) ? "https://${var.domain}" : "https://${terraform.workspace}.${var.domain}"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000
     },
     {
       allowed_methods = ["GET"]
-      allowed_origins = ["https://${terraform.workspace}.${var.domain}"]
+      allowed_origins = [contains(["prod"], terraform.workspace) ? "https://${var.domain}" : "https://${terraform.workspace}.${var.domain}"]
     }
   ]
 }
@@ -105,13 +105,13 @@ module "ndr-bulk-staging-store" {
     {
       allowed_headers = ["*"]
       allowed_methods = ["POST", "PUT", "DELETE"]
-      allowed_origins = ["https://${terraform.workspace}.${var.domain}"]
+      allowed_origins = [contains(["prod"], terraform.workspace) ? "https://${var.domain}" : "https://${terraform.workspace}.${var.domain}"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000
     },
     {
       allowed_methods = ["GET"]
-      allowed_origins = ["https://${terraform.workspace}.${var.domain}"]
+      allowed_origins = [contains(["prod"], terraform.workspace) ? "https://${var.domain}" : "https://${terraform.workspace}.${var.domain}"]
     }
   ]
 }


### PR DESCRIPTION
Two of the S3 buckets have missing logic on the CORS allowed origins, causing them to have the prod prefix in production.