### PR TITLE
[NDR-213] Create ACM per workspace

### DIFF
--- a/infrastructure/acm_certificate.tf
+++ b/infrastructure/acm_certificate.tf
@@ -1,5 +1,4 @@
 resource "aws_acm_certificate" "mtls_api_gateway_cert" {
-  count             = local.is_sandbox ? 0 : 1
   domain_name       = local.mtls_api_gateway_full_domain_name
   validation_method = "DNS"
 
@@ -10,8 +9,8 @@ resource "aws_acm_certificate" "mtls_api_gateway_cert" {
 
 # Record used by ACM for DNS Validation
 resource "aws_route53_record" "validation" {
-  for_each = local.is_sandbox ? {} : {
-    for dvo in aws_acm_certificate.mtls_api_gateway_cert[0].domain_validation_options :
+  for_each = {
+    for dvo in aws_acm_certificate.mtls_api_gateway_cert.domain_validation_options :
     dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
@@ -28,7 +27,6 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "mtls_api_gateway_cert" {
-  count                   = local.is_sandbox ? 0 : 1
-  certificate_arn         = aws_acm_certificate.mtls_api_gateway_cert[0].arn
+  certificate_arn         = aws_acm_certificate.mtls_api_gateway_cert.arn
   validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
 }


### PR DESCRIPTION
As the certificate is assigned to a specified domain (mtls.ndr-dev.access-request-fulfilment.patient-deductions.nhs.uk) this won't work for sandboxes (which have their own gateways and custom domains) unless another alias is specified. 

As it is only dev where there will be multiple workspaces, it makes sense to create one cert per workspace. In higher environments there will only be one certificate per persistent environment. 