### PR TITLE
[NDR-244] Add policies to Fhir lambdas for reading db and s3

### DIFF
--- a/infrastructure/lambda-get-document-fhir.tf
+++ b/infrastructure/lambda-get-document-fhir.tf
@@ -40,8 +40,10 @@ module "get-doc-fhir-lambda" {
   iam_role_policy_documents = [
     module.ndr-app-config.app_config_policy,
     module.lloyd_george_reference_dynamodb_table.dynamodb_read_policy_document,
+    module.pdm_dynamodb_table.dynamodb_read_policy_document,
     aws_iam_policy.ssm_access_policy.policy,
     module.ndr-lloyd-george-store.s3_read_policy_document,
+    module.pdm-document-store.s3_read_policy_document,
   ]
   kms_deletion_window = var.kms_deletion_window
   rest_api_id         = aws_api_gateway_rest_api.ndr_doc_store_api.id

--- a/infrastructure/lambda-post-document-fhir.tf
+++ b/infrastructure/lambda-post-document-fhir.tf
@@ -5,6 +5,7 @@ module "post-document-references-fhir-lambda" {
   iam_role_policy_documents = [
     module.document_reference_dynamodb_table.dynamodb_write_policy_document,
     module.lloyd_george_reference_dynamodb_table.dynamodb_write_policy_document,
+    module.pdm_dynamodb_table.dynamodb_write_policy_document,
     module.ndr-bulk-staging-store.s3_write_policy_document,
     module.ndr-app-config.app_config_policy,
     aws_iam_policy.ssm_access_policy.policy

--- a/infrastructure/lambda-search-document-references-fhir.tf
+++ b/infrastructure/lambda-search-document-references-fhir.tf
@@ -7,6 +7,8 @@ module "search-document-references-fhir-lambda" {
     module.document_reference_dynamodb_table.dynamodb_write_policy_document,
     module.lloyd_george_reference_dynamodb_table.dynamodb_read_policy_document,
     module.lloyd_george_reference_dynamodb_table.dynamodb_write_policy_document,
+    module.pdm_dynamodb_table.dynamodb_read_policy_document,
+    module.pdm_dynamodb_table.dynamodb_write_policy_document,
     module.ndr-lloyd-george-store.s3_read_policy_document,
     module.ndr-document-store.s3_read_policy_document,
     module.ndr-app-config.app_config_policy


### PR DESCRIPTION
This tickets relate to ENV Var changes in NDR-244. However it was found as a bug during the testing of NDR-272.